### PR TITLE
Tabs --> 4 spaces, rename replace_in_file()

### DIFF
--- a/Youtube-dl downloader.py
+++ b/Youtube-dl downloader.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # author: Shaun Hevey
-# youtube-dl downloader is used to download youtube_dl and make it work with pythonista.
+# youtube-dl downloader is used to download youtube_dl and patch it to work in Pythonista.
 # Replace function came from http://stackoverflow.com/questions/39086/search-and-replace-a-line-in-a-file-in-python
 # Download file was adapted from Python file downloader (https://gist.github.com/89edf288a15fde45682a)
 
@@ -26,81 +26,78 @@ files_to_change = [('utils.py','import ctypes','#import ctypes'),
                    ('extractor/common.py',' and sys.stderr.isatty()','')]
 
 def backup_youtubedl(sender):
-	console.show_activity('Checking for youtube-dl')
-	if os.path.isdir(youtubedl_location+youtubedl_dir):
-		console.show_activity('Backing up youtube-dl')
-		if not os.path.exists(backup_location):
-			os.makedirs(backup_location)
-		shutil.move(youtubedl_location+youtubedl_dir,backup_location+youtubedl_dir+ time.strftime('%Y%m%d%H%M%S'))
-	console.hide_activity()
+    console.show_activity('Checking for youtube-dl')
+    if os.path.isdir(youtubedl_location+youtubedl_dir):
+        console.show_activity('Backing up youtube-dl')
+        if not os.path.exists(backup_location):
+            os.makedirs(backup_location)
+        shutil.move(youtubedl_location+youtubedl_dir,backup_location+youtubedl_dir+ time.strftime('%Y%m%d%H%M%S'))
+    console.hide_activity()
 
 @ui.in_background
 def restore_youtubedl_backup(sender):
-	if not os.path.isdir(backup_location) or not os.listdir(backup_location):
-		console.alert('Nothing to do', 'No backups found to restore')
-	else: 
-		folders = os.listdir(backup_location)
-		folder = folders[len(folders)-1]
-		shutil.move(backup_location+folder,youtubedl_location+youtubedl_dir)
-		console.alert('Success','Successfully restored '+folder)
+    if not os.path.isdir(backup_location) or not os.listdir(backup_location):
+        console.alert('Nothing to do', 'No backups found to restore')
+    else:
+        folders = os.listdir(backup_location)
+        folder = folders[len(folders)-1]
+        shutil.move(backup_location+folder,youtubedl_location+youtubedl_dir)
+        console.alert('Success','Successfully restored '+folder)
 
 def downloadfile(url):
-	localFilename = url.split('/')[-1] or 'download'
-	with open(localFilename, 'wb') as f:
-		r = requests.get(url, stream=True)
-		total_length = r.headers.get('content-length')
-		if total_length:
-			dl = 0
-			total_length = float(total_length)
-			for chunk in r.iter_content(1024):
-				dl += len(chunk)
-				f.write(chunk)
-				#.setprogress(dl/total_length*100.0)
-		else:
-			f.write(r.content)
-	return localFilename
+    localFilename = url.split('/')[-1] or 'download'
+    with open(localFilename, 'wb') as f:
+        r = requests.get(url, stream=True)
+        total_length = r.headers.get('content-length')
+        if total_length:
+            dl = 0
+            total_length = float(total_length)
+            for chunk in r.iter_content(1024):
+                dl += len(chunk)
+                f.write(chunk)
+                #.setprogress(dl/total_length*100.0)
+        else:
+            f.write(r.content)
+    return localFilename
 
 def process_file(path):
-	if zipfile.is_zipfile(path):
-		zipfile.ZipFile(path).extractall()
+    if zipfile.is_zipfile(path):
+        zipfile.ZipFile(path).extractall()
 
-@ui.in_background	
+@ui.in_background
 def update_youtubedl(sender):
-	if os.path.exists(youtubedl_location+youtubedl_dir):
-		msg = 'Are you sure you want to update youtubedl exists in site-packages and will be overwritten'
-		if not console.alert('Continue',msg,'OK'):
-			return
-	console.show_activity('Downloading')
-	file = downloadfile(youtubedl_downloadurl)
-	console.show_activity('Extracting')
-	process_file(file)
-	console.show_activity('Moving')
-	if os.path.exists(youtubedl_location+youtubedl_dir):
-		shutil.rmtree(youtubedl_location+youtubedl_dir)
-	shutil.move(youtubedl_unarchive_location+youtubedl_dir, youtubedl_location)
-	
-	console.show_activity('Cleaning Up Download Files')
-	shutil.rmtree(youtubedl_unarchive_location)
-	os.remove(file)
-	console.show_activity('Making youtube-dl friendly')
-	process_youtubedl_for_pythonista()
-	console.hide_activity()
-		
-def process_youtubedl_for_pythonista():
-	for file in files_to_change:
-		replace(youtubedl_location+youtubedl_dir+'/'+file[0],file[1],file[2])
+    if os.path.exists(youtubedl_location+youtubedl_dir):
+        msg = 'Are you sure you want to update youtubedl exists in site-packages and will be overwritten'
+        if not console.alert('Continue',msg,'OK'):
+            return
+    console.show_activity('Downloading')
+    file = downloadfile(youtubedl_downloadurl)
+    console.show_activity('Extracting')
+    process_file(file)
+    console.show_activity('Moving')
+    if os.path.exists(youtubedl_location+youtubedl_dir):
+        shutil.rmtree(youtubedl_location+youtubedl_dir)
+    shutil.move(youtubedl_unarchive_location+youtubedl_dir, youtubedl_location)
+    console.show_activity('Cleaning Up Download Files')
+    shutil.rmtree(youtubedl_unarchive_location)
+    os.remove(file)
+    console.show_activity('Making youtube-dl friendly')
+    process_youtubedl_for_pythonista()
+    console.hide_activity()
 
-def replace(file_path, pattern, subst):
-    #Create temp file
-    fh, abs_path = tempfile.mkstemp()
-    new_file = open(abs_path,'w')
-    old_file = open(file_path)
-    for line in old_file:
-    	new_file.write(line.replace(pattern, subst))
-    #close temp file
-    new_file.close()
-    os.close(fh)
-    old_file.close()
+def process_youtubedl_for_pythonista():
+    for patch in files_to_change:
+        filename, old_str, new_str = patch
+        replace_in_file(youtubedl_location+youtubedl_dir+'/'+filename, old_str, new_str)
+
+def replace_in_file(file_path, old_str, new_str):
+    with open(file_path) as old_file:
+        #Create temp file
+        fh, abs_path = tempfile.mkstemp()
+        os.close(fh)  # close low level and reopen high level
+        with open(abs_path,'w') as new_file:
+            for line in old_file:
+                new_file.write(line.replace(old_str, new_str))
     #Remove original file
     os.remove(file_path)
     #Move new file


### PR DESCRIPTION
http://omz-forums.appspot.com/pythonista/post/5316756860043264 For rational for spaces.

Renamed replace() to replace_in_file() to clarify difference from str.replace() and string.replace().  Used `with open()` to ensure files are closed even if there are errors.  Start by reading old_file and throw an exception if old_file does not exist _before_ creating new_file.

[`file()`](https://docs.python.org/2/library/functions.html?highlight=file#file) is a builtin function so it is better to avoid using `file` as a variable name.
